### PR TITLE
Added ability to define an array of SERVER_NAME options for each environ...

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -13,9 +13,9 @@
  */
 
 
-// Define Environments
+// Define Environments - may be a string or array of options for an environment
 $environments = array(
-	'local'       => '.local',
+	'local'       => array('.local', 'local.'),
 	'development' => '.dev',
 	'staging'     => 'stage.',
 	'preview'     => 'preview.',
@@ -26,13 +26,31 @@ $server_name = $_SERVER['SERVER_NAME'];
 
 foreach($environments AS $key => $env){
 
-	if(strstr($server_name, $env)){
+	if(is_array($env)){
 
-		define('ENVIRONMENT', $key);
+		foreach ($env as $option){
 
-		break;
+			if(stristr($server_name, $option)){
 
+				define('ENVIRONMENT', $key);
+				
+				break 2;
+			}
+
+		}
+
+	} else {
+
+		if(strstr($server_name, $env)){
+
+			define('ENVIRONMENT', $key);
+
+			break;
+
+		}
+		
 	}
+
 }
 
 // If no environment is set default to production


### PR DESCRIPTION
...ment in addition to just using a string.

Thought you might want to pull this change. This allows you to specify an array of options for each environment instead of just a single string. 

Example:

``` php
$environments = array(
    'local'       => array('.local', 'local.'),
    'development' => '.dev',
    'staging'     => 'stage.',
    'preview'     => 'preview.',
);
```
