### PR TITLE
Use stristr for both basic string and array of options for environment

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -41,7 +41,7 @@ foreach($environments AS $key => $env){
 
 	} else {
 
-		if(strstr($server_name, $env)){
+		if(stristr($server_name, $env)){
 
 			define('ENVIRONMENT', $key);
 


### PR DESCRIPTION
Thought there was no reason to use strstr in one place, and stristr in the other?
